### PR TITLE
fix:安装依赖缺少posts.data.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "files": [
     ".vitepress/fix-katex.js",
     ".vitepress/genFeed.mjs",
-    ".vitepress/posts.data.js",
+    ".vitepress/posts.data.mjs",
     ".vitepress/theme"
   ]
 }


### PR DESCRIPTION
解决下载依赖缺失posts.data.mjs